### PR TITLE
Made the profile pic slightly more centered for my device

### DIFF
--- a/app/src/main/res/layout/activity_post.xml
+++ b/app/src/main/res/layout/activity_post.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.constraint.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -26,8 +25,8 @@
         android:layout_marginTop="32dp"
         android:layout_marginEnd="40dp"
         android:ems="10"
-        android:inputType="textPersonName"
         android:hint="@string/caption"
+        android:inputType="textPersonName"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.975"
         app:layout_constraintStart_toStartOf="parent"
@@ -39,8 +38,8 @@
         android:layout_height="150dp"
         android:ems="10"
         android:gravity="top"
+        android:hint="@string/purpose"
         android:inputType="textPersonName"
-        android:text="@string/purpose"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.493"
@@ -92,15 +91,13 @@
         android:id="@+id/profile_image"
         android:layout_width="50dp"
         android:layout_height="50dp"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="24dp"
         android:src="@drawable/oski"
         app:civ_border_color="#FF000000"
         app:civ_border_width="2dp"
-        app:layout_constraintBottom_toBottomOf="@+id/image_view"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.044"
-        app:layout_constraintStart_toStartOf="@+id/image_view"
-        app:layout_constraintTop_toTopOf="parent"
-        app:layout_constraintVertical_bias="0.193" />
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/imageButtonBack" />
 
     <TextView
         android:id="@+id/tvName"
@@ -112,17 +109,16 @@
         android:textSize="18sp"
         app:layout_constraintBottom_toTopOf="@+id/image_view"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.05"
+        app:layout_constraintHorizontal_bias="0.054"
         app:layout_constraintStart_toEndOf="@+id/profile_image"
         app:layout_constraintTop_toBottomOf="@+id/divider"
-        app:layout_constraintVertical_bias="0.34" />
+        app:layout_constraintVertical_bias="0.489" />
 
     <ImageButton
         android:id="@+id/imageButtonBack"
         android:layout_width="80dp"
         android:layout_height="80dp"
         android:background="#00000000"
-        app:layout_constraintBottom_toTopOf="@+id/profile_image"
         app:layout_constraintEnd_toStartOf="@+id/textView_new_post"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
Make the profile pic slightly more centered on my device. 

The divider and the imageView collided and it looked really bad. This was to keep it consistent. 

![Screenshot_20191125-205419_Social A](https://user-images.githubusercontent.com/7614179/69600661-53acdb80-0fc6-11ea-9d36-fa58bb858099.jpg)
